### PR TITLE
Add "LLM Critics Help Catch LLM Bugs" to Scalable Oversight

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
-# ⚖️ **Awesome LLM Judges** ⚖️  
-*This repo curates recent research on LLM Judges for automated evaluation.*
+# ⚖️ **Awesome LLM Judges** ⚖️
+
+_This repo curates recent research on LLM Judges for automated evaluation._
 
 > [!TIP]
 > ⚖️ Check out [Verdict](https://verdict.haizelabs.com) — our in-house library for hassle-free implementations of the papers below!
@@ -7,6 +8,7 @@
 ---
 
 ## 📚 Table of Contents
+
 - [🌱 Starter](#-starter)
 - [🎭 Ensemble](#-ensemble)
   - [🤔 Debate](#-debate)
@@ -24,55 +26,65 @@
 ---
 
 ## 🌱 Starter
-- [Judging LLM-as-a-Judge with MT-Bench and Chatbot Arena](https://arxiv.org/abs/2306.05685)  
-- [G-EVAL: NLG Evaluation using GPT-4 with Better Human Alignment](https://arxiv.org/abs/2303.16634)  
+
+- [Judging LLM-as-a-Judge with MT-Bench and Chatbot Arena](https://arxiv.org/abs/2306.05685)
+- [G-EVAL: NLG Evaluation using GPT-4 with Better Human Alignment](https://arxiv.org/abs/2303.16634)
 - [Benchmarking Foundation Models with Language-Model-as-an-Examiner](https://arxiv.org/abs/2306.04181)
 
 ---
 
 ## 🎭 Multi-Judge
+
 - [Replacing Judges with Juries: Evaluating LLM Generations with a Panel of Diverse Models](https://arxiv.org/abs/2404.18796)
 
 ### 🤔 Debate
+
 - [ScaleEval: Scalable Meta-Evaluation of LLMs as Evaluators via Agent Debate](https://arxiv.org/abs/2401.16788)
-- [ChatEval: Towards Better LLM-based Evaluators through Multi-Agent Debate](https://arxiv.org/abs/2308.07201)  
-- [Can ChatGPT Defend its Belief in Truth? Evaluating LLM Reasoning via Debate](https://arxiv.org/abs/2305.13160)  
-- [Debating with More Persuasive LLMs Leads to More Truthful Answers](https://arxiv.org/abs/2402.06782)  
+- [ChatEval: Towards Better LLM-based Evaluators through Multi-Agent Debate](https://arxiv.org/abs/2308.07201)
+- [Can ChatGPT Defend its Belief in Truth? Evaluating LLM Reasoning via Debate](https://arxiv.org/abs/2305.13160)
+- [Debating with More Persuasive LLMs Leads to More Truthful Answers](https://arxiv.org/abs/2402.06782)
 
 ---
 
 ## 🎯 Finetuned Models
-- [Prometheus: Inducing Fine-grained Evaluation Capability in Language Models](https://arxiv.org/abs/2310.08491)  
-- [Prometheus 2: An Open Source Language Model Specialized in Evaluating Other Language Models](https://arxiv.org/abs/2405.01535)  
-- [JudgeLM: Fine-tuned Large Language Models are Scalable Judges](https://arxiv.org/abs/2310.17631)  
+
+- [Prometheus: Inducing Fine-grained Evaluation Capability in Language Models](https://arxiv.org/abs/2310.08491)
+- [Prometheus 2: An Open Source Language Model Specialized in Evaluating Other Language Models](https://arxiv.org/abs/2405.01535)
+- [JudgeLM: Fine-tuned Large Language Models are Scalable Judges](https://arxiv.org/abs/2310.17631)
 
 ### 🌀 Hallucination
-- [HALU-J: Critique-Based Hallucination Judge](https://arxiv.org/abs/2407.12943)  
-- [MiniCheck: Efficient Fact-Checking of LLMs on Grounding Documents](https://aclanthology.org/2024.emnlp-main.499/)  
-- [Lynx: An Open Source Hallucination Evaluation Model](https://arxiv.org/abs/2407.08488)  
+
+- [HALU-J: Critique-Based Hallucination Judge](https://arxiv.org/abs/2407.12943)
+- [MiniCheck: Efficient Fact-Checking of LLMs on Grounding Documents](https://aclanthology.org/2024.emnlp-main.499/)
+- [Lynx: An Open Source Hallucination Evaluation Model](https://arxiv.org/abs/2407.08488)
 
 ### 🏆 Generative Reward Models
-- [Generative Verifiers: Reward Modeling as Next-Token Prediction](https://arxiv.org/abs/2408.15240)  
-- [Critique-out-Loud Reward Models](https://arxiv.org/abs/2408.11791)  
+
+- [Generative Verifiers: Reward Modeling as Next-Token Prediction](https://arxiv.org/abs/2408.15240)
+- [Critique-out-Loud Reward Models](https://arxiv.org/abs/2408.11791)
 
 ---
 
 ## 🛡️ Safety
 
 ### 🛑 Content Moderation
+
 - [A STRONGREJECT for Empty Jailbreaks (Sections C.4 & C.5)](https://arxiv.org/pdf/2402.10260)
 - [OR-Bench: An Over-Refusal Benchmark for Large Language Models (Sections A.3 & A.11)](https://arxiv.org/abs/2405.20947)
 - [WildGuard: Open One-Stop Moderation Tools for Safety Risks, Jailbreaks, and Refusals of LLMs](https://arxiv.org/abs/2406.18495)
 - [Llama Guard: LLM-based Input-Output Safeguard for Human-AI Conversations](https://arxiv.org/abs/2312.06674)
 
 ### 🔍 Scalable Oversight
-- [On Scalable Oversight with Weak LLMs Judging Strong LLMs](https://arxiv.org/abs/2407.04622)  
+
+- [On Scalable Oversight with Weak LLMs Judging Strong LLMs](https://arxiv.org/abs/2407.04622)
 - [Debate Helps Supervise Unreliable Experts](https://arxiv.org/abs/2311.08702)
 - [Great Models Think Alike and this Undermines AI Oversight](https://arxiv.org/abs/2502.04313)
+- [LLM Critics Help Catch LLM Bugs](https://arxiv.org/abs/2407.00215)
 
 ---
 
 ## 👨‍⚖️ Judging the Judges: Meta-Evaluation
+
 - [JudgeBench: A Benchmark for Evaluating LLM-based Judges](https://arxiv.org/abs/2410.12784)
 - [RewardBench: Evaluating Reward Models for Language Modeling](https://arxiv.org/abs/2403.13787)
 - [Evaluating Large Language Models at Evaluating Instruction Following](https://arxiv.org/abs/2310.07641)
@@ -84,19 +96,23 @@
 - [ReIFE: Re-evaluating Instruction-Following Evaluation](https://arxiv.org/abs/2410.07069)
 
 ### ⚖️ Biases
-- [Large Language Models are not Fair Evaluators](https://arxiv.org/abs/2305.17926)  
+
+- [Large Language Models are not Fair Evaluators](https://arxiv.org/abs/2305.17926)
 - [Large Language Models Sensitivity to The Order of Options in Multiple-Choice Questions](https://arxiv.org/abs/2308.11483)
 - [Large Language Models are Inconsistent and Biased Evaluators](https://arxiv.org/abs/2405.01724)
-- [Judging the Judges: Evaluating Alignment and Vulnerabilities in LLMs-as-Judges](https://arxiv.org/abs/2406.12624)  
+- [Judging the Judges: Evaluating Alignment and Vulnerabilities in LLMs-as-Judges](https://arxiv.org/abs/2406.12624)
 
 ---
 
 ## 🤖 Agents
-*🚧 Coming Soon -- Stay tuned!*
+
+_🚧 Coming Soon -- Stay tuned!_
 
 ---
 
 ## ✨ Contributing
-Have a paper to add? Found a mistake? 🧐  
-- Open a pull request or submit an issue! Contributions are welcome. 🙌  
-- Questions? Reach out to [leonard@haizelabs.com](mailto:leonard@haizelabs.com).  
+
+Have a paper to add? Found a mistake? 🧐
+
+- Open a pull request or submit an issue! Contributions are welcome. 🙌
+- Questions? Reach out to [leonard@haizelabs.com](mailto:leonard@haizelabs.com).


### PR DESCRIPTION
**Paper Added**:  
[LLM Critics Help Catch Bugs in Reasoning](https://arxiv.org/abs/2407.00215) (McAleese et al., OpenAI, 2024)  

**Section Added**:  
`🔍 Scalable Oversight` (under the [🛡️ Safety](#️-safety) category)  

**Rationale**:  
- This paper introduces **CriticGPT**, an LLM trained to generate critiques that help humans detect bugs in code and reasoning errors, directly addressing scalable oversight challenges in RLHF.  
- Fits under **Scalable Oversight** as it aligns with existing works like [On Scalable Oversight with Weak LLMs Judging Strong LLMs](https://arxiv.org/abs/2407.04622), focusing on improving human evaluation of AI outputs.  
- Alternative placement could be under `🏆 Generative Reward Models`, but the emphasis on oversight/safety makes this the primary fit.  

**Note**: Open to moving to another section if maintainers prefer!  